### PR TITLE
IDG-19: Upgrade to Groovy 2.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 .DS_Store
 bin
 activemq-data
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,14 @@ subprojects { subproject ->
 
 		compile "org.codehaus.groovy:groovy-all:$groovyVersion"
 
-		testCompile "junit:junit-dep:$junitVersion"
-		testRuntime "log4j:log4j:$log4jVersion"
-		testCompile "org.mockito:mockito-all:$mockitoVersion"
+		testCompile ("junit:junit:$junitVersion") {
+			exclude group: 'org.hamcrest'
+		}
+		testCompile "log4j:log4j:$log4jVersion"
+		testCompile "org.hamcrest:hamcrest-all:$hamcrestVersion"
+		testCompile ("org.mockito:mockito-core:$mockitoVersion") {
+			exclude group: 'org.hamcrest'
+		}
 	}
 
 
@@ -189,7 +194,7 @@ def customizePom(def pom, def gradleProject) {
 				}
 			}
 			scm {
-				url = 'https://github.com/SpringSource/spring-integration-groovy-dsl'
+				url = 'https://github.com/spring-projects/spring-integration-dsl-groovy'
 				connection = 'scm:git:git://github.com/spring-projects/spring-integration-dsl-groovy'
 				developerConnection = 'scm:git:ssh://git@github.com:spring-projects/spring-integration-dsl-groovy'
 			}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
 version = 1.1.0.BUILD-SNAPSHOT
 activeMqVersion = 5.9.0
-groovyVersion = 2.1.6
+groovyVersion = 2.2.2
 jmsApiVersion = 1.1-rev-1
-junitVersion = 4.8.2
-log4jVersion = 1.2.14
-mockitoVersion = 1.9.0
+junitVersion = 4.11
+log4jVersion = 1.2.17
+mockitoVersion = 1.9.5
+hamcrestVersion = 1.3
 servletApiVersion = 3.1.0
 springIntegrationVersion = 4.0.0.BUILD-SNAPSHOT

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/IntegrationComponent.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/IntegrationComponent.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -16,13 +16,12 @@ import org.apache.commons.logging.LogFactory
 
 /**
  * The base class for all components defined in the DSL model
- * 
+ *
  * @author David Turanski
  *
  */
 //todo change when @Trait comes to Groovy
-@Mixin(AttributeHelper)
-@Mixin(ComponentNamer)
+@Mixin([AttributeHelper, ComponentNamer])
 //@CompileStatic
 abstract class IntegrationComponent   {
 	protected logger = LogFactory.getLog(this.class)

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilder.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -129,9 +129,9 @@ class IntegrationBuilder extends FactoryBuilderSupport {
 	}
 
 	@Override
-	protected dispathNodeCall(name, args){
+	protected dispatchNodeCall(name, args){
 		use (IntegrationBuilderCategory) {
-			super.dispathNodeCall(name, args)
+			super.dispatchNodeCall(name, args)
 		}
 	}
 
@@ -238,10 +238,10 @@ class IntegrationBuilder extends FactoryBuilderSupport {
 		}
 
 		if (logger.isDebugEnabled()) {
-			logger.debug("invoking dispathNodeCall for name: $name with args: $list")
+			logger.debug("invoking dispatchNodeCall for name: $name with args: $list")
 		}
 
-		dispathNodeCall(name,list as Object[])
+		dispatchNodeCall(name,list as Object[])
 	}
 
 	def springXml(Closure closure) {

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationContextFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationContextFactory.groovy
@@ -1,36 +1,31 @@
 /*
- * Copyright 2002-2012 the original author or authors.
- * 
+ * Copyright 2002-2014 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package org.springframework.integration.dsl.groovy.builder
 
-import java.util.Map
-import groovy.util.FactoryBuilderSupport
-
-import org.apache.commons.logging.Log
-import org.apache.commons.logging.LogFactory
-
+import org.springframework.context.ApplicationContext
 /**
  * @author David Turanski
  *
  */
-class IntegrationContextFactory extends IntegrationComponentFactory { 
+class IntegrationContextFactory extends IntegrationComponentFactory {
 	protected Object doNewInstance(FactoryBuilderSupport builder, Object name, Object value, Map attributes){
 		return builder.integrationContext;
 	}
-	
+
 	@Override
 	void onNodeCompleted( FactoryBuilderSupport builder, Object parent, Object integrationContext ) {
 		if (builder.autoCreateApplicationContext) {
-			integrationContext.createApplicationContext(builder.parentContext)
+			integrationContext.createApplicationContext((ApplicationContext) builder.parentContext)
 		}
 	}
 }

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/MessageFlowFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/MessageFlowFactory.groovy
@@ -1,18 +1,18 @@
 /*
- * Copyright 2002-2012 the original author or authors.
- * 
+ * Copyright 2002-2014 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package org.springframework.integration.dsl.groovy.builder
 
-import org.springframework.integration.dsl.groovy.IntegrationContext
+import org.springframework.context.ApplicationContext
 import org.springframework.integration.dsl.groovy.MessageFlow
 /**
  * @author David Turanski
@@ -41,7 +41,7 @@ class MessageFlowFactory extends IntegrationComponentFactory {
 			}
 			builder.integrationContext.add(messageFlow)
 			if (builder.autoCreateApplicationContext) {
-				builder.integrationContext.createApplicationContext(builder.parentContext)
+				builder.integrationContext.createApplicationContext((ApplicationContext) builder.parentContext)
 			}
 		}
 	}

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/SplitterTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/SplitterTests.groovy
@@ -12,8 +12,6 @@
  */
 package org.springframework.integration.dsl.groovy.builder
 
-import static org.junit.Assert.*
-
 import org.junit.Test
 
 import org.springframework.messaging.support.GenericMessage


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTDSLGROOVY-19
- Fix double `@Mixin` issue
- Fix ambiguity of `IntegrationContext.createApplicationContext` methods, when `builder.parentContext == null`
- Fix deprecated `dispathNodeCall` method usage
