### PR TITLE
GH-15: Fix `IC.getMessageFlowByName()`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,12 +140,6 @@ task 'run-cafe'(type: JavaExec) {
 	workingDir = 'spring-integration-dsl-groovy-samples'
 }
 
-task wrapper(type: Wrapper) {
-	description = 'Generates gradlew[.bat] scripts'
-	gradleVersion = '2.3'
-	distributionUrl = "http://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
-}
-
 def customizePom(def pom, def gradleProject) {
 	pom.whenConfigured { generatedPom ->
 		// respect 'optional' and 'provided' dependencies

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.3-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.5-all.zip

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/IntegrationContext.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/IntegrationContext.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -109,7 +109,7 @@ class IntegrationContext extends BaseIntegrationComposition {
 	 * @return the MessageFlow
 	 */
 	MessageFlow getMessageFlowByName(String name){
-		messageFlows.find {it.name = name}
+		messageFlows.find {it.name == name}
 	}
 
 	/**

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilderTests.java
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilderTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2012 the original author or authors.
- * 
+ * Copyright 2002-2016 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -13,6 +13,7 @@
 package org.springframework.integration.dsl.groovy.builder;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -56,9 +57,13 @@ public class IntegrationBuilderTests {
 		IntegrationContext ic = (IntegrationContext) builder.build(new FileInputStream(
 				"src/test/resources/messageflow1.groovy"));
 		MessageFlow flow1 = ic.getMessageFlowByName("flow1");
+		assertEquals("flow1.inputChannel", flow1.getInputChannel());
 		flow1.send("hello");
+		MessageFlow flow2 = ic.getMessageFlowByName("flow2");
+		assertNotNull(flow2);
+		assertEquals("flow2.inputChannel", flow2.getInputChannel());
 	}
-	
+
 	@Test
 	public void testPropertyPlaceholderConfigurerPresent() throws FileNotFoundException {
 		IntegrationContext ic = (IntegrationContext) builder.build(new FileInputStream(


### PR DESCRIPTION
Fixes GH-15 (https://github.com/spring-projects/spring-integration-dsl-groovy/issues/15)

Previously the `IntegrationContext.getMessageFlowByName()` made an assignment of the incoming filter name to the to the first object in the collection
and returned it.

Fix assignment to the equal operator. Add an appropriate test-case