### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project implements a Groovy DSL for Spring Integration. Coming on the heels
 * May be executed direclty in Groovy or from a Java class
 
 ## Implementation
-The DSL uses Groovy Builder pattern so the syntax will be familiar to Groovyists. The central class is the *IntegrationBuilder* which extends  [FactoryBuilderSupport](http://groovy.codehaus.org/FactoryBuilderSupport) framework to create a Spring Integration domain model which is translated directly to Spring XML to create a Spring Application Context. 
+The DSL uses Groovy Builder pattern so the syntax will be familiar to Groovyists. The central class is the *IntegrationBuilder* which extends  [FactoryBuilderSupport](https://groovy.codehaus.org/FactoryBuilderSupport) framework to create a Spring Integration domain model which is translated directly to Spring XML to create a Spring Application Context. 
 
 The main benefit of this approach is that the DSL can leverage existing Spring Integration namespace parsers to perform all the necessary validation and bean definition processing. Since this code is tightly coupled to XML parsing, the bean definitions and would otherwise need to be entirely replicated for the DSL. Another advantage is that if the log level is set to DEBUG, you can inspect the generated XML on the console which will give you more insight into how the DSL interprets things. Finally it makes it very easy for the IntegrationBuilder to inject XML builder markup, providing seamless integration with Spring XML.
 

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/XMLNamespaceSupport.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/XMLNamespaceSupport.groovy
@@ -20,8 +20,8 @@ package org.springframework.integration.dsl.groovy.builder.dom
  */
 class XMLNamespaceSupport {
 	static final String REQUIRED_SCHEMA_LOCATIONS =
-	"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd "+
-	"http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd"
+	"http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd "+
+	"http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd"
 
 	static final String DEFAULT_INTEGRATION_NAMESPACE_PREFIX = 'si'
 
@@ -42,7 +42,7 @@ class XMLNamespaceSupport {
 	/**
 	 * Add an XML namespace for a Spring Integration component using Spring Integration conventions
 	 * Example: The prefix 'int-jms' generates xmlns:int-jms="http://www.springframework.org/schema/integration/jms" and
-	 * binds the namespace URL to the schema location "http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd"
+	 * binds the namespace URL to the schema location "https://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd"
 	 * @param prefix the namespace prefix - If it starts with 'int-' the component name will be the remaining characters otherwise the
 	 * namespace prefix will be the same as the component name.
 	 */

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/dom/XMLNamespaceSupportTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/dom/XMLNamespaceSupportTests.groovy
@@ -35,7 +35,7 @@ class XMLNamespaceSupportTests {
 		namespaceSupport.addIntegrationNamespace('jms')
 
 		assert namespaceSupport.schemaLocations.contains(
-		'http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd')
+		'https://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd')
 
 		assert namespaceSupport.schemaLocations != XMLNamespaceSupport.REQUIRED_NAMESPACE_DECLARATIONS
 		assert namespaceSupport.namespaceDeclarations.jms == 'http://www.springframework.org/schema/integration/jms'

--- a/spring-integration-dsl-groovy-feed/src/test/groovy/sample.rss
+++ b/spring-integration-dsl-groovy-feed/src/test/groovy/sample.rss
@@ -1,7 +1,7 @@
 <rss version="2.0">
 <channel>
 <title>Spring Integration</title>
-<link>http://www.springsource.org/spring-integration</link>
+<link>https://www.springsource.org/spring-integration</link>
 <description>
 Spring Integration is a really cool framework
 </description>
@@ -11,16 +11,16 @@ All Rights Reserved.</copyright>
 <lastBuildDate>Tue, 12 Apr 2010 18:21:32 EST</lastBuildDate>
 <ttl>240</ttl>
 <image>
-<url>http://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png</url>
+<url>https://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png</url>
 <title>Spring Integration</title>
-<link>http://www.springsource.org/spring-integration</link>
+<link>https://www.springsource.org/spring-integration</link>
 </image>
 
 <item>
 <title>
 Spring Integration adapters
 </title>
-<link>http://www.springsource.org/extensions/se-sia</link>
+<link>https://www.springsource.org/extensions/se-sia</link>
 <description>
 Spring Integration adapters are realy cool
 </description>
@@ -31,7 +31,7 @@ Spring Integration adapters are realy cool
 <title>
 Spring Integration download
 </title>
-<link>http://www.springsource.com/products/spring-community-download</link>
+<link>https://www.springsource.com/products/spring-community-download</link>
 <description>
 Download Spring Integration
 </description>
@@ -42,7 +42,7 @@ Download Spring Integration
 <title>
 Check out Spring Integration forums
 </title>
-<link>http://forum.springsource.org/forumdisplay.php?f=42</link>
+<link>https://forum.spring.io/forumdisplay.php?f=42</link>
 <description>
 Spring Integration forums are awesome
 </description>

--- a/spring-integration-dsl-groovy-http/src/test/resources/httpMessageFlow1.groovy
+++ b/spring-integration-dsl-groovy-http/src/test/resources/httpMessageFlow1.groovy
@@ -1,3 +1,3 @@
 messageFlow {
-	httpGet(url:{"http://www.google.com/finance/info?q=$it"},responseType:String)
+	httpGet(url:{"https://www.google.com/finance/info?q=$it"},responseType:String)
 }

--- a/spring-integration-dsl-groovy-samples/src/main/groovy/org/springframework/integration/samples/http/HttpExamples.groovy
+++ b/spring-integration-dsl-groovy-samples/src/main/groovy/org/springframework/integration/samples/http/HttpExamples.groovy
@@ -17,7 +17,7 @@ public class HttpExamples {
 		 * Demonstrates defining url as a closure
 		 */
 		def flow = builder.messageFlow {
-				httpGet(url:{"http://www.google.com/finance/info?q=$it"},responseType:String)
+				httpGet(url:{"https://www.google.com/finance/info?q=$it"},responseType:String)
 		}		
 						
 		def result = flow.sendAndReceive('VMW')


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://www.foo.com (200) with 1 occurrences could not be migrated:  
   ([https](https://www.foo.com) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://groovy.codehaus.org/FactoryBuilderSupport (UnknownHostException) with 1 occurrences migrated to:  
  https://groovy.codehaus.org/FactoryBuilderSupport ([https](https://groovy.codehaus.org/FactoryBuilderSupport) result UnknownHostException).
* [ ] http://www.google.com/finance/info?q= (403) with 2 occurrences migrated to:  
  https://www.google.com/finance/info?q= ([https](https://www.google.com/finance/info?q=) result 403).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd ([https](https://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd) result 200).
* [ ] http://www.springframework.org/schema/integration/spring-integration.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* [ ] http://forum.springsource.org/forumdisplay.php?f=42 (301) with 1 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?f=42 ([https](https://forum.springsource.org/forumdisplay.php?f=42) result 301).
* [ ] http://www.springsource.com/products/spring-community-download with 1 occurrences migrated to:  
  https://www.springsource.com/products/spring-community-download ([https](https://www.springsource.com/products/spring-community-download) result 301).
* [ ] http://www.springsource.org/spring-integration with 2 occurrences migrated to:  
  https://www.springsource.org/spring-integration ([https](https://www.springsource.org/spring-integration) result 301).
* [ ] http://www.springsource.org/extensions/se-sia with 1 occurrences migrated to:  
  https://www.springsource.org/extensions/se-sia ([https](https://www.springsource.org/extensions/se-sia) result 302).
* [ ] http://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png with 1 occurrences migrated to:  
  https://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png ([https](https://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png) result 302).

# Ignored
These URLs were intentionally ignored.

* http://test/news/rss.xml with 3 occurrences
* http://test/rss.xml with 3 occurrences
* http://www.springframework.org/schema/ with 1 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/integration with 5 occurrences
* http://www.springframework.org/schema/integration/ with 1 occurrences
* http://www.springframework.org/schema/integration/http with 1 occurrences
* http://www.springframework.org/schema/integration/jms with 3 occurrences
* http://www.springframework.org/schema/jms with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences