### PR TITLE
URL Cleanup

### DIFF
--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/AmqpInbound.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/AmqpInbound.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/AmqpOutbound.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/AmqpOutbound.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/AmqpInboundFactory.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/AmqpInboundFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/AmqpOutboundFactory.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/AmqpOutboundFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/IntegrationBuilderModuleSupport.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/IntegrationBuilderModuleSupport.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitAdminFactory.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitAdminFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitBuilder.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitConnectionFactoryFactory.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitConnectionFactoryFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitContextFactory.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitContextFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitExchangeFactory.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitExchangeFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitQueueFactory.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitQueueFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitTemplateFactory.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/RabbitTemplateFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/dom/AmqpInboundDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/dom/AmqpInboundDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/dom/AmqpOutboundDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/main/groovy/org/springframework/integration/dsl/groovy/amqp/builder/dom/AmqpOutboundDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-amqp/src/test/groovy/org/springframework/integration/dsl/groovy/amqp/builder/AmqpUsageTests.groovy
+++ b/spring-integration-dsl-groovy-amqp/src/test/groovy/org/springframework/integration/dsl/groovy/amqp/builder/AmqpUsageTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/AttributeHelper.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/AttributeHelper.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/BaseIntegrationComposition.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/BaseIntegrationComposition.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/ChannelInterceptors.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/ChannelInterceptors.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/Channels.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/Channels.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/ClosureInvokingComponents.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/ClosureInvokingComponents.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/ComponentNamer.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/ComponentNamer.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/GatewayEndpoint.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/GatewayEndpoint.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/IntegrationComponent.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/IntegrationComponent.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/IntegrationContext.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/IntegrationContext.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/MessageFlow.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/MessageFlow.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/Poller.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/Poller.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/SimpleEndpoints.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/SimpleEndpoints.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/SpringModuleContext.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/SpringModuleContext.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/XMLBean.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/XMLBean.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/XMLNamespace.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/XMLNamespace.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/AbstractIntegrationBuilderModuleSupport.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/AbstractIntegrationBuilderModuleSupport.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/ChannelFactories.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/ChannelFactories.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/ChannelMapFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/ChannelMapFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/FlowExecutionFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/FlowExecutionFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationComponentFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationComponentFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationContextFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationContextFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/MessageFlowFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/MessageFlowFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/PollerFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/PollerFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/RouterFactories.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/RouterFactories.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/SimpleEndpointFactories.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/SimpleEndpointFactories.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/SpringXmlComponentFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/SpringXmlComponentFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/XMLBeanFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/XMLBeanFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/XMLNamespaceFactory.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/XMLNamespaceFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/AggregatorDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/AggregatorDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/ChannelDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/ChannelDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/ChannelInterceptorDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/ChannelInterceptorDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/GenericDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/GenericDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/IntegrationComponentDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/IntegrationComponentDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/IntegrationDomSupport.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/IntegrationDomSupport.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/MessageFlowDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/MessageFlowDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/RouterDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/RouterDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/SimpleEndpointDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/SimpleEndpointDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/SpringXMLBuilder.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/SpringXMLBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/XMLNamespaceSupport.groovy
+++ b/spring-integration-dsl-groovy-core/src/main/groovy/org/springframework/integration/dsl/groovy/builder/dom/XMLNamespaceSupport.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/ClosureInvokerTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/ClosureInvokerTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/ClosureInvokingChannelInterceptorTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/ClosureInvokingChannelInterceptorTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/IntegrationComponentTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/IntegrationComponentTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/MultiMessageParameterTransformerTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/MultiMessageParameterTransformerTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/SimpleEndpointsTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/SimpleEndpointsTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/AggregatorTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/AggregatorTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/ChannelInterceptorTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/ChannelInterceptorTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/ChannelTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/ChannelTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilderTests.java
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilderTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilderUsageTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/IntegrationBuilderUsageTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/MessageFlowTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/MessageFlowTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/PollerTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/PollerTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/RouterUsageTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/RouterUsageTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/SimpleTransformerTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/SimpleTransformerTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/SplitterTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/SplitterTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/XMLBeanTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/XMLBeanTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/dom/IntegrationMarkupSupportTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/dom/IntegrationMarkupSupportTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/dom/XMLNamespaceSupportTests.groovy
+++ b/spring-integration-dsl-groovy-core/src/test/groovy/org/springframework/integration/dsl/groovy/builder/dom/XMLNamespaceSupportTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-feed/src/main/groovy/org/springframework/integration/dsl/groovy/feed/FeedSubscriber.groovy
+++ b/spring-integration-dsl-groovy-feed/src/main/groovy/org/springframework/integration/dsl/groovy/feed/FeedSubscriber.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-feed/src/main/groovy/org/springframework/integration/dsl/groovy/feed/builder/FeedSubscriberFactory.groovy
+++ b/spring-integration-dsl-groovy-feed/src/main/groovy/org/springframework/integration/dsl/groovy/feed/builder/FeedSubscriberFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-feed/src/main/groovy/org/springframework/integration/dsl/groovy/feed/builder/IntegrationBuilderModuleSupport.groovy
+++ b/spring-integration-dsl-groovy-feed/src/main/groovy/org/springframework/integration/dsl/groovy/feed/builder/IntegrationBuilderModuleSupport.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-feed/src/main/groovy/org/springframework/integration/dsl/groovy/feed/builder/dom/FeedSubscriberDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-feed/src/main/groovy/org/springframework/integration/dsl/groovy/feed/builder/dom/FeedSubscriberDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-feed/src/test/groovy/org/springframework/integration/dsl/groovy/feed/builder/FeedSubscriberTests.groovy
+++ b/spring-integration-dsl-groovy-feed/src/test/groovy/org/springframework/integration/dsl/groovy/feed/builder/FeedSubscriberTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-feed/src/test/groovy/org/springframework/integration/dsl/groovy/feed/builder/FileUrlFeedFetcher.groovy
+++ b/spring-integration-dsl-groovy-feed/src/test/groovy/org/springframework/integration/dsl/groovy/feed/builder/FileUrlFeedFetcher.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-groovy-feed/src/test/groovy/org/springframework/integration/dsl/groovy/feed/builder/SampleMetadataStore.groovy
+++ b/spring-integration-dsl-groovy-feed/src/test/groovy/org/springframework/integration/dsl/groovy/feed/builder/SampleMetadataStore.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-groovy-http/src/main/groovy/org/springframework/integration/dsl/groovy/http/HttpOutbound.groovy
+++ b/spring-integration-dsl-groovy-http/src/main/groovy/org/springframework/integration/dsl/groovy/http/HttpOutbound.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-http/src/main/groovy/org/springframework/integration/dsl/groovy/http/builder/HttpOutboundFactory.groovy
+++ b/spring-integration-dsl-groovy-http/src/main/groovy/org/springframework/integration/dsl/groovy/http/builder/HttpOutboundFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-http/src/main/groovy/org/springframework/integration/dsl/groovy/http/builder/IntegrationBuilderModuleSupport.groovy
+++ b/spring-integration-dsl-groovy-http/src/main/groovy/org/springframework/integration/dsl/groovy/http/builder/IntegrationBuilderModuleSupport.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-http/src/main/groovy/org/springframework/integration/dsl/groovy/http/builder/dom/HttpOutboundDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-http/src/main/groovy/org/springframework/integration/dsl/groovy/http/builder/dom/HttpOutboundDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-http/src/test/groovy/org/springframework/integration/dsl/groovy/http/builder/HttpOutboundJavaTests.groovy
+++ b/spring-integration-dsl-groovy-http/src/test/groovy/org/springframework/integration/dsl/groovy/http/builder/HttpOutboundJavaTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-http/src/test/groovy/org/springframework/integration/dsl/groovy/http/builder/HttpOutboundTests.groovy
+++ b/spring-integration-dsl-groovy-http/src/test/groovy/org/springframework/integration/dsl/groovy/http/builder/HttpOutboundTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/JmsListener.groovy
+++ b/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/JmsListener.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by aplicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/JmsOutbound.groovy
+++ b/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/JmsOutbound.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/IntegrationBuilderModuleSupport.groovy
+++ b/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/IntegrationBuilderModuleSupport.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/JmsListenerFactory.groovy
+++ b/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/JmsListenerFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/JmsOutboundFactory.groovy
+++ b/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/JmsOutboundFactory.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/dom/JmsListenerDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/dom/JmsListenerDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/dom/JmsOutboundDomBuilder.groovy
+++ b/spring-integration-dsl-groovy-jms/src/main/groovy/org/springframework/integration/dsl/groovy/jms/builder/dom/JmsOutboundDomBuilder.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-jms/src/test/groovy/org/springframework/integration/dsl/groovy/jms/builder/JmsUsageTests.groovy
+++ b/spring-integration-dsl-groovy-jms/src/test/groovy/org/springframework/integration/dsl/groovy/jms/builder/JmsUsageTests.groovy
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Barista.java
+++ b/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Barista.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Cafe.java
+++ b/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Cafe.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Delivery.java
+++ b/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Delivery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Drink.java
+++ b/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Drink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/DrinkType.java
+++ b/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/DrinkType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Main.java
+++ b/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Main.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Order.java
+++ b/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Order.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/OrderItem.java
+++ b/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/OrderItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Waiter.java
+++ b/spring-integration-dsl-groovy-samples/src/main/java/org/springframework/integration/samples/cafe/Waiter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 103 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).